### PR TITLE
Migrate MVC project to netcoreapp3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+sample/MongoIdentitySample.Mvc/appsettings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,4 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 sample/MongoIdentitySample.Mvc/appsettings.local.json
+test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.local.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/sample/MongoIdentitySample.Mvc/bin/Debug/netcoreapp3.1/MongoIdentitySample.Mvc.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/sample/MongoIdentitySample.Mvc",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,19 +27,20 @@ steps:
     projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
-- task: VSTest@2
+- task: DotNetCoreCLI@2
   inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+    command: 'build'
+    projects: './test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj'
+    arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   inputs:
     command: 'pack'
-    packagesToPack: './src/AspNetCore.Identity.MongoDbCore.csproj'
+    packagesToPack: './src/AspnetCore.Identity.MongoDbCore.nuspec'
     versioningScheme: 'off'
-    arguments: '--configuration $(buildConfiguration) -p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
     modifyOutputPath: true
     packDirectory: $(build.artifactStagingDirectory)/Nuget
+    nobuild: true
 
 - task: NuGetCommand@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ variables:
 steps:
 
 - task: UseDotNet@2
+  displayName: 'Install .net core 3.1'
   inputs:
     packageType: 'sdk'
     version: '3.1.101'
@@ -24,22 +25,26 @@ steps:
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2
+  displayName: 'Restore Library Dependencies'
   inputs:
     restoreSolution: '$(solution)'
 
 - task: DotNetCoreCLI@2
+  displayName: 'Build Library'
   inputs:
     command: 'build'
     projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
+  displayName: 'Test Library'
   inputs:
     command: 'test'
     projects: './test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
+  displayName: 'Package Library'
   inputs:
     command: 'pack'
     packagesToPack: './src/AspnetCore.Identity.MongoDbCore.csproj'
@@ -49,15 +54,8 @@ steps:
     nobuild: true
     verbosityPack: 'Minimal'
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'pack'
-    packagesToPack: '**/*.csproj'
-    nobuild: true
-    versioningScheme: 'off'
-    verbosityPack: 'Minimal'
-
 - task: NuGetCommand@2
+  displayName: 'Publish Library'
   inputs:
     command: 'push'
     packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,14 +44,11 @@ steps:
 #     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
-  displayName: 'Package Library'
   inputs:
-    command: 'pack'
-    packagesToPack: './src/AspNetCore.Identity.MongoDbCore.csproj'
-    versioningScheme: 'off'
-    arguments: '-p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
-    packDirectory: $(build.artifactStagingDirectory)/Nuget
-    nobuild: true
+    command: 'custom'
+    projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
+    custom: 'pack'
+    arguments: '--no-build -p:NuspecFile=AspNetCore.Identity.MongoDbCore.nuspec -o  $(build.artifactStagingDirectory)/Nuget'
     verbosityPack: 'Detailed'
 
 - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-latest'
 
 variables:
   solution: '**/*.sln'
@@ -29,7 +29,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   inputs:
-    command: 'build'
+    command: 'test'
     projects: './test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
@@ -41,6 +41,15 @@ steps:
     arguments: '-p:NuspecFile=./src/AspnetCore.Identity.MongoDbCore.nuspec'
     packDirectory: $(build.artifactStagingDirectory)/Nuget
     nobuild: true
+    verbosityPack: 'Minimal'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'pack'
+    packagesToPack: '**/*.csproj'
+    nobuild: true
+    versioningScheme: 'off'
+    verbosityPack: 'Minimal'
 
 - task: NuGetCommand@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ steps:
     command: 'pack'
     packagesToPack: './src/AspnetCore.Identity.MongoDbCore.csproj'
     versioningScheme: 'off'
-    arguments: '-p:NuspecFile=./src/AspnetCore.Identity.MongoDbCore.nuspec'
+    arguments: '-p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
     packDirectory: $(build.artifactStagingDirectory)/Nuget
     nobuild: true
-    verbosityPack: 'Minimal'
+    verbosityPack: 'Normal'
 
 - task: NuGetCommand@2
   displayName: 'Publish Library'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,12 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.101'
+
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,12 +36,12 @@ steps:
     projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Test Library'
-  inputs:
-    command: 'test'
-    projects: './test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj'
-    arguments: '--configuration $(buildConfiguration)'
+# - task: DotNetCoreCLI@2
+#   displayName: 'Test Library'
+#   inputs:
+#     command: 'test'
+#     projects: './test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj'
+#     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Package Library'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-# ASP.NET Core (.NET Framework)
-# Build and test ASP.NET Core projects targeting the full .NET Framework.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
 - master
@@ -44,6 +40,7 @@ steps:
 #     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
+  displayName: 'Package Library (nuget)'
   inputs:
     command: 'custom'
     projects: './src/AspNetCore.Identity.MongoDbCore.csproj'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,50 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
+    arguments: '--configuiration $(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'pack'
+    packagesToPack: './src/AspNetCore.Identity.MongoDbCore.csproj'
+    versioningScheme: 'off'
+    arguments: '-p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
+    modifyOutputPath: true
+    packDirectory: $(build.artifactStagingDirectory)/Nuget
+
+- task: NuGetCommand@2
+  inputs:
+    command: 'push'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+    nuGetFeedType: 'internal'
+    publishVstsFeed: '72ef5435-c019-4338-8d35-7c3caec78f2a'
+    verbosityPush: 'Normal'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
   inputs:
     command: 'build'
     projects: './src/AspNetCore.Identity.MongoDbCore.csproj'
-    arguments: '--configuiration $(buildConfiguration)'
+    arguments: '--configuration $(buildConfiguration)'
 
 - task: VSTest@2
   inputs:
@@ -37,7 +37,7 @@ steps:
     command: 'pack'
     packagesToPack: './src/AspNetCore.Identity.MongoDbCore.csproj'
     versioningScheme: 'off'
-    arguments: '-p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
+    arguments: '--configuration $(buildConfiguration) -p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
     modifyOutputPath: true
     packDirectory: $(build.artifactStagingDirectory)/Nuget
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,9 +36,9 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: 'pack'
-    packagesToPack: './src/AspnetCore.Identity.MongoDbCore.nuspec'
+    packagesToPack: './src/AspnetCore.Identity.MongoDbCore.csproj'
     versioningScheme: 'off'
-    modifyOutputPath: true
+    arguments: '-p:NuspecFile=./src/AspnetCore.Identity.MongoDbCore.nuspec'
     packDirectory: $(build.artifactStagingDirectory)/Nuget
     nobuild: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,12 +47,12 @@ steps:
   displayName: 'Package Library'
   inputs:
     command: 'pack'
-    packagesToPack: './src/AspnetCore.Identity.MongoDbCore.csproj'
+    packagesToPack: './src/AspNetCore.Identity.MongoDbCore.csproj'
     versioningScheme: 'off'
     arguments: '-p:NuspecFile=AspnetCore.Identity.MongoDbCore.nuspec'
     packDirectory: $(build.artifactStagingDirectory)/Nuget
     nobuild: true
-    verbosityPack: 'Normal'
+    verbosityPack: 'Detailed'
 
 - task: NuGetCommand@2
   displayName: 'Publish Library'

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,10 @@
+
+$project="./src/AspNetCore.Identity.MongoDbCore.csproj"
+$testProject="./test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj"
+$configuration="Release"
+$nuspecFile="AspnetCore.Identity.MongoDbCore.nuspec"
+$output="./nuget"
+
+dotnet build
+dotnet test $testProject
+dotnet pack --no-restore --no-build $project --configuration $configuration -p:NuspecFile=$nuspecFile -o $output

--- a/sample/MongoIdentitySample.Mvc/.vscode/launch.json
+++ b/sample/MongoIdentitySample.Mvc/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/MongoIdentitySample.Mvc.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"                
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/sample/MongoIdentitySample.Mvc/.vscode/tasks.json
+++ b/sample/MongoIdentitySample.Mvc/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/MongoIdentitySample.Mvc.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj
+++ b/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj
@@ -3,24 +3,23 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-MongoIdentitySample.Mvc-95B15D82-54F6-4001-B4B0-6ADF4B1BB00E</UserSecretsId>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0-beta1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/MongoIdentitySample.Mvc/Program.cs
+++ b/sample/MongoIdentitySample.Mvc/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace MongoIdentitySample.Mvc
 {
@@ -11,15 +12,14 @@ namespace MongoIdentitySample.Mvc
     {
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-                .UseApplicationInsights()
-                .Build();
-
-            host.Run();
+            CreateHostBuilder(args).Build().Run();
         }
+
+        protected static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/sample/MongoIdentitySample.Mvc/Startup.cs
+++ b/sample/MongoIdentitySample.Mvc/Startup.cs
@@ -15,8 +15,10 @@ namespace MongoIdentitySample.Mvc
 {
     public class Startup
     {
+        private IWebHostEnvironment _env;
         public Startup(IWebHostEnvironment env)
         {
+            _env = env;
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
@@ -38,11 +40,21 @@ namespace MongoIdentitySample.Mvc
             var settings = Configuration.GetSection(nameof(MongoDbSettings)).Get<MongoDbSettings>();
 
             services.AddSingleton<MongoDbSettings>(settings);
-            
+
             services.AddIdentity<ApplicationUser, MongoIdentityRole>()
                     .AddMongoDbStores<ApplicationUser, MongoIdentityRole, Guid>(settings.ConnectionString, settings.DatabaseName)
                     .AddSignInManager()
                     .AddDefaultTokenProviders();
+
+
+            var builder = services.AddRazorPages();
+            
+            #if DEBUG
+                if(_env.IsDevelopment())
+                {
+                    builder.AddRazorRuntimeCompilation();
+                }
+            #endif
 
             services.AddMvc();
 

--- a/sample/MongoIdentitySample.Mvc/Startup.cs
+++ b/sample/MongoIdentitySample.Mvc/Startup.cs
@@ -9,17 +9,20 @@ using MongoIdentitySample.Mvc.Services;
 using AspNetCore.Identity.MongoDbCore.Models;
 using Microsoft.AspNetCore.Identity;
 using AspNetCore.Identity.MongoDbCore.Infrastructure;
+using Microsoft.Extensions.Hosting;
 
 namespace MongoIdentitySample.Mvc
 {
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                //per user config that is not committed to repo, use this to override settings (e.g. connection string) based on your local environment.
+                .AddJsonFile($"appsettings.local.json", optional: true); 
 
             if (env.IsDevelopment())
             {
@@ -47,13 +50,15 @@ namespace MongoIdentitySample.Mvc
 
             services.AddMvc();
 
+            services.AddApplicationInsightsTelemetry();
+
             // Add application services.
             services.AddTransient<IEmailSender, AuthMessageSender>();
             services.AddTransient<ISmsSender, AuthMessageSender>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env) //, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env) //, ILoggerFactory loggerFactory)
         {
             //loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             //loggerFactory.AddDebug();
@@ -74,13 +79,6 @@ namespace MongoIdentitySample.Mvc
             app.UseAuthentication();
             app.UseAuthorization();
             // Add external authentication middleware below. To configure them please see https://go.microsoft.com/fwlink/?LinkID=532715
-
-            //app.UseMvc(routes =>
-            //{
-            //    routes.MapRoute(
-            //        name: "default",
-            //        template: "{controller=Home}/{action=Index}/{id?}");
-            //});
 
             app.UseEndpoints(endpoints =>
             {

--- a/sample/MongoIdentitySample.Mvc/Views/Shared/_Layout.cshtml
+++ b/sample/MongoIdentitySample.Mvc/Views/Shared/_Layout.cshtml
@@ -31,7 +31,7 @@
             @RenderBody()
             <hr />
             <footer>
-                <p>&copy; 2016 - IdentitySample</p>
+                <p>&copy; 2020 - IdentitySample</p>
             </footer>
         </div>
 

--- a/sample/MongoIdentitySample.Mvc/bundleconfig.json
+++ b/sample/MongoIdentitySample.Mvc/bundleconfig.json
@@ -1,9 +1,6 @@
-﻿// Configure bundling and minification for the project.
-// More info at https://go.microsoft.com/fwlink/?LinkId=808241
-[
-  {
+﻿[
+{
     "outputFileName": "wwwroot/css/site.min.css",
-    // An array of relative input file paths. Globbing patterns supported
     "inputFiles": [
       "wwwroot/css/site.css"
     ]
@@ -13,12 +10,10 @@
     "inputFiles": [
       "wwwroot/js/site.js"
     ],
-    // Optionally specify minification options
     "minify": {
       "enabled": true,
       "renameLocals": true
     },
-    // Optionally generate .map file
     "sourceMap": false
   }
 ]

--- a/src/AspNetCore.Identity.MongoDbCore.nuspec
+++ b/src/AspNetCore.Identity.MongoDbCore.nuspec
@@ -2,11 +2,11 @@
 <package >
   <metadata>
     <id>AspNetCore.Identity.MongoDbCore</id>
-    <version>1.1.1</version>
+    <version>2.1.0</version>
     <title>AspNetCore.Identity.MongoDbCore</title>
     <authors>Alexandre Spieser</authors>
     <owners>Alexandre Spieser</owners>
-    <licenseUrl>http://www.opensource.org/licenses/mit-license.php</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/alexandre-spieser/AspNetCore.Identity.MongoDbCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A MongoDb UserStore and RoleStore adapter for Microsoft.AspNetCore.Identity 2.0.</description>
@@ -14,13 +14,21 @@
     <copyright>Copyright 2018 (c) Alexandre Spieser. All rights reserved.</copyright>
     <tags>aspnetcore mongo mongodb identity membership</tags>
 	<dependencies>
-		<dependency id="Microsoft.AspNetCore.Identity" version="2.2.0" />
-		<dependency id="Microsoft.Extensions.Identity.Stores" version="2.2.0" />
-		<dependency id="MongoDB.Driver" version="2.7.0" />
-		<dependency id="MongoDbGenericRepository" version="1.4.0" />
+        <group targetFramework="netstandard2.1">
+            <dependency id="Microsoft.AspNetCore.Identity" version="[2.2,3)" />
+            <dependency id="Microsoft.Extensions.Identity.Stores" version="[3.1,4)" />
+            <dependency id="MongoDB.Driver" version="[2.10,3)" />
+            <dependency id="MongoDbGenericRepository" version="[1.4,2)" />
+        </group>
+        <group targetFramework="netcoreapp3.1">
+            <dependency id="Microsoft.AspNetCore.Identity" version="[2.2,3)" />
+            <dependency id="Microsoft.Extensions.Identity.Stores" version="[3.1,4)" />
+            <dependency id="MongoDB.Driver" version="[2.10,3)" />
+            <dependency id="MongoDbGenericRepository" version="[1.4,2)" />
+        </group>
 	</dependencies>
   </metadata>
   <files>
-    <file src="lib\**" target="lib" />
+    <file src="bin\Release\**\*" exclude="*.pdb" target="lib" />
   </files>
 </package>

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj
@@ -33,4 +33,9 @@
     <ProjectReference Include="..\..\src\AspNetCore.Identity.MongoDbCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="appsettings*.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>  
+  </ItemGroup>
 </Project>

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Infrastructure/Container.cs
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Infrastructure/Container.cs
@@ -23,7 +23,7 @@ namespace AspNetCore.Identity.MongoDbCore.IntegrationTests.Infrastructure
                                     //per user config that is not committed to repo, use this to override settings (e.g. connection string) based on your local environment.
                                     .AddJsonFile($"appsettings.local.json", optional: true); 
 
-            //builder.AddEnvironmentVariables();
+            builder.AddEnvironmentVariables();
 
             Configuration = builder.Build();
 

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "MongoDbSettings": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "MongoDbTests"
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Migrate MVC project to netcoreapp3.1

Updated the project in line with the recommendations from Microsoft
https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio
And
https://docs.microsoft.com/en-us/aspnet/core/migration/30-to-31?view=aspnetcore-3.1&tabs=visual-studio

Also added runtime compilation.