### PR TITLE
Add IDictionary<string, string> Properties on MongoClaim #54

### DIFF
--- a/src/Extensions/ClaimHolderExtensions.cs
+++ b/src/Extensions/ClaimHolderExtensions.cs
@@ -23,7 +23,8 @@ namespace AspNetCore.Identity.MongoDbCore.Extensions
             {
                 Type = claim.Type,
                 Value = claim.Value,
-                Issuer = claim.Issuer
+                Issuer = claim.Issuer,
+                Properties = claim.Properties
             };
         }
 
@@ -34,7 +35,12 @@ namespace AspNetCore.Identity.MongoDbCore.Extensions
         /// <returns> A <see cref="Claim"/>.</returns>
         public static Claim ToClaim(this MongoClaim mongoClaim)
         {
-            return new Claim(mongoClaim.Type, mongoClaim.Value, null, mongoClaim.Issuer);
+            var claim = new Claim(mongoClaim.Type, mongoClaim.Value, null, mongoClaim.Issuer);
+            foreach (var (key, value) in mongoClaim.Properties)
+            {
+                claim.Properties.Add(key, value);
+            }
+            return claim;
         }
 
         /// <summary>
@@ -75,6 +81,7 @@ namespace AspNetCore.Identity.MongoDbCore.Extensions
                            oldClaim.Type = newClaim.Type;
                            oldClaim.Value = newClaim.Value;
                            oldClaim.Issuer = newClaim.Issuer;
+                           oldClaim.Properties = newClaim.Properties;
                            replaced |= true;
                        });
             return replaced;

--- a/src/Models/MongoClaim.cs
+++ b/src/Models/MongoClaim.cs
@@ -1,4 +1,6 @@
-﻿namespace AspNetCore.Identity.MongoDbCore.Models
+﻿using System.Collections.Generic;
+
+namespace AspNetCore.Identity.MongoDbCore.Models
 {
     /// <summary>
     /// A class representing the claims a <see cref="MongoIdentityUser{TKey}"/> can have.
@@ -17,5 +19,11 @@
         /// The issuer of the claim.
         /// </summary>
         public string Issuer { get; set; }
+
+        /// <summary>
+        /// Gets a dictionary that contains additional properties associated with this claim
+        /// </summary>
+        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
     }
 }


### PR DESCRIPTION
**Description**
System.Security.Claims.Claim contains a property named Properties of type IDictionary<string,string> which doesn't exist in MongoClaim. This property can be used to store additional metadata which can be consumed at runtime which is currently not possible. This change should enable persisting Properties from Claim to MongoClaim and retrieve them later.