### PR TITLE
Upgrade Package to dotnet 6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/sample/MongoIdentitySample.Mvc/bin/Debug/netcoreapp3.1/MongoIdentitySample.Mvc.dll",
+            "program": "${workspaceFolder}/sample/MongoIdentitySample.Mvc/bin/Debug/net6.0/MongoIdentitySample.Mvc.dll",
             "args": [],
             "cwd": "${workspaceFolder}/sample/MongoIdentitySample.Mvc",
             "stopAtEntry": false,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,10 @@ variables:
 steps:
 
 - task: UseDotNet@2
-  displayName: 'Install .net core 3.1'
+  displayName: Install .NET 6.0
   inputs:
     packageType: 'sdk'
-    version: '3.1.101'
+    version: '6.0.x'
 
 - task: NuGetToolInstaller@1
 

--- a/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj
+++ b/sample/MongoIdentitySample.Mvc/MongoIdentitySample.Mvc.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.12" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.8" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/MongoIdentitySample.Mvc/appsettings.json
+++ b/sample/MongoIdentitySample.Mvc/appsettings.json
@@ -6,7 +6,7 @@
   "Logging": {
     "IncludeScopes": {},
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information"
     }
   }
 }

--- a/scripts/update-projects.ps1
+++ b/scripts/update-projects.ps1
@@ -1,0 +1,211 @@
+# Copyright (c) 2022 David Barker all rights reserved
+# Licensed under MIT
+param (
+    [string] $dir = "./src",
+    [string] $from = "net6.0",
+    [string] $to = "net6.0",
+    [switch] $migrate = $false,
+    [switch] $update = $false,
+    [switch] $clean = $false,
+    [switch] $restore = $false
+)
+
+function Main([string] $dir, [string] $targetFramework)
+{
+    $validSettings = $restore -or $clean -or $migrate -or $update
+
+    if ($validSettings -eq $false)
+    {
+        Write-Host ""
+        Write-Host "Usage:"
+        Write-Host "update-projects.ps1 -dir [dir] -clean -migrate -restore -update -from -to"
+        Write-Host ""
+        Write-Host " -dir : The directory to start the processing, will search recursively"
+        Write-Host " -clean : removes bin and obj directories recursively"
+        Write-Host " -update : re-adds the packages to force version update to latest package version"
+        Write-Host " -restore : forces a dotnet restore on all the projects"
+        Write-Host " -migrate : replaces the current framework with the target framework, must supply -from and -to"
+        Write-Host " -from : the framework to update netstandard2.1, net6.0 etc"
+        Write-Host " -to : the new framework version netstandard2.1, net6.0 etc"
+        Write-Host ""
+        Write-Host ""
+
+        Dump-Settings
+
+        return
+    }
+
+    Dump-Settings
+
+    if ($clean)
+    {
+        Remove-Obj -directory $dir
+        Remove-Bin -directory $dir
+    }
+
+    if ($migrate)
+    {
+        Update-Framework -directory $dir -targetFramework $targetFramework
+        Update-Launch -directory $dir -targetFramework $targetFramework
+    }
+
+    if ($update)
+    {
+        Update-Packages -directory $dir -targetFramework $targetFramework
+    }
+
+    if ($restore)
+    {
+        Restore-Projects -directory $dir
+    }
+}
+
+function Dump-Settings()
+{
+    Write-Host "Current Settings:"
+    Write-Host "  -dir      : $dir"
+    Write-Host "  -clean    : $clean"
+    Write-Host "  -migrate  : $migrate"
+    Write-Host "  -update   : $update"
+    Write-Host "  -restore  : $restore"
+    Write-Host "  -from     : $from"
+    Write-Host "  -to       : $to"
+}
+
+function Restore-Projects([string] $dir)
+{
+    Write-Host "Restore Projects"
+
+    $projectFiles = Get-ChildItem $dir -Recurse -Filter *.csproj
+
+    foreach ($projectFile in $projectFiles)
+    {
+        Write-Host "  Project: $($projectFile.Name)"
+
+        if ($update)
+        {
+            & dotnet restore "$($projectFile.Directory.FullName)"
+        }
+    }
+}
+
+function Update-Framework([string] $dir, [string] $targetFramework)
+{
+    if ($migrate -eq $true)
+    {
+        $projectFiles = Get-ChildItem $dir -Recurse -Filter *.csproj
+
+        Write-Host "Find and update projects from $($from) to $($to)"
+
+        foreach ($projectFile in $projectFiles)
+        {
+            $projectXml = [xml](Get-Content $projectFile.FullName)
+
+            if ($projectXml.Project.Sdk -ne "")
+            {
+                Write-Host "  Project: $($projectFile.Name) Current Setting: $($projectXml.Project.PropertyGroup.TargetFramework)"
+                $currentFramework = $projectXml.Project.PropertyGroup.TargetFramework;
+                $upgrade = $currentFramework -eq $from -and $currentFramework -ne $to
+                if ($upgrade)
+                {
+                    if ($null -ne $projectXml.Project.PropertyGroup[0].TargetFramework)
+                    {
+                        Write-Host "    Migrate Project to $targetFramework.."
+                        $projectXml.Project.PropertyGroup[0].TargetFramework = $targetFramework
+                    }
+                    else
+                    {
+                        Write-Host "    Migrate Project to $targetFramework."
+                        $projectXml.Project.PropertyGroup.TargetFramework = $targetFramework
+                    }
+                    $projectXml.Save($projectFile.FullName)
+                }
+                else
+                {
+                    Write-Host "   - Nothing to do! Skipping!"
+                }
+
+            }
+        }
+    }
+}
+
+function Update-Packages([string] $dir, [string] $targetFramework)
+{
+    if ($update -eq $true)
+    {
+        $projectFiles = Get-ChildItem $dir -Recurse -Filter *.csproj
+
+        foreach ($projectFile in $projectFiles)
+        {
+            $projectXml = [xml](Get-Content $projectFile.FullName)
+
+            if ($projectXml.Project.Sdk -ne "")
+            {
+                $itemGroups = $projectXml.Project.ItemGroup
+
+                Write-Host "  Project: $($projectFile.Name) Current Setting: $($projectXml.Project.PropertyGroup.TargetFramework)"
+
+                Write-Host "    Update Packages:"
+
+                foreach ($itemGroup in $itemGroups)
+                {
+                    if ($itemGroup.PackageReference)
+                    {
+                        foreach ($packageRef in $itemGroup.PackageReference)
+                        {
+                            Write-Host "      Package: $($packageRef.Include)"
+                            & dotnet add "$($projectFile)" package "$($packageRef.Include)" | Out-File -FilePath "dotnet.log" -Append
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}
+function Update-Launch([string] $dir, [string] $targetFramework)
+{
+    Write-Host "Migrate Launch Files"
+    $launchFiles = Get-ChildItem $dir -Recurse -Force -Filter launch.json
+
+    foreach ($launchFile in $launchFiles)
+    {
+        Write-Host "." -NoNewline
+
+        $newContent = (Get-Content $launchFile -Raw) -replace "/$from/", "/$targetFramework/"
+
+        $newContent | Set-Content -Path $launchFile.FullName
+    }
+    Write-Host " [done]"
+}
+
+function Remove-Bin([string] $dir)
+{
+    Write-Host "Remove Bin Directories"
+    $binDirectories = Get-ChildItem $dir -Recurse -Force -Directory -Filter bin
+
+    foreach ($binDirectory in $binDirectories)
+    {
+        Write-Host "." -NoNewline
+        Remove-Item -Path $binDirectory.FullName -Recurse -Force
+    }
+    Write-Host " [done]"
+}
+
+function Remove-Obj([string] $dir)
+{
+    Write-Host "Remove Obj Directories"
+    $binDirectories = Get-ChildItem $dir -Recurse -Force -Directory -Filter obj
+
+    foreach ($binDirectory in $binDirectories)
+    {
+        Write-Host "." -NoNewline
+        Remove-Item -Path $binDirectory.FullName -Recurse -Force
+    }
+    Write-Host " [done]"
+}
+
+$targetFramework = $to
+
+Main -dir $dir -targetFramework $targetFramework

--- a/src/AspNetCore.Identity.MongoDbCore.csproj
+++ b/src/AspNetCore.Identity.MongoDbCore.csproj
@@ -1,16 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Nuget Package properties -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>AspNetCore.Identity.MongoDbCore</PackageId>
     <Authors>Alexandre Spieser</Authors>
     <PackageTitle>AspNetCore.Identity.MongoDbCore</PackageTitle>
-    <Description>A MongoDb UserStore and RoleStore adapter for Microsoft.Extensions.Identity.Core 3.1.</Description>
-    <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
-    <PackageProjectUrl>http://www.opensource.org/licenses/mit-license.php</PackageProjectUrl>
+    <Description>A MongoDb UserStore and RoleStore adapter for Microsoft.Extensions.Identity.Core 6.0.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>Release notes are at Release notes are at https://github.com/alexandre-spieser/AspNetCore.Identity.MongoDbCore/releases</PackageReleaseNotes>
     <Copyright>Copyright 2021 (c) Alexandre Spieser. All rights reserved.</Copyright>
@@ -18,19 +17,26 @@
     <RepositoryUrl>https://github.com/alexandre-spieser/AspNetCore.Identity.MongoDbCore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <!-- Versioning -->
-    <PackageVersion>3.1.2</PackageVersion>
-    <Version>3.1.2</Version>
-    <FileVersion>3.1.2</FileVersion>
+    <PackageVersion>6.0.0</PackageVersion>
+    <Version>6.0.0</Version>
+    <FileVersion>6.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.12" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.8" />
+    <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
+    <PackageReference Include="MongoDbGenericRepository" Version="1.4.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.8" />
+    <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
     <PackageReference Include="MongoDbGenericRepository" Version="1.4.8" />
   </ItemGroup>
 

--- a/src/MongoUserStore.cs
+++ b/src/MongoUserStore.cs
@@ -406,7 +406,7 @@ namespace AspNetCore.Identity.MongoDbCore
 
             //if(user.Roles.Any(e => e.Equals(roleEntity.Id)))
             //{
-            //    throw new InvalidOperationException($"User {user.Id} is already in role {roleEntity.Name}.");
+            //    throw new InvalidOperationException($"User is already in role {roleEntity.Name}.");
             //}
 
             if (user.AddRole(roleEntity.Id))

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/AspNetCore.Identity.MongoDbCore.IntegrationTests.csproj
@@ -1,37 +1,33 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.12" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
     <PackageReference Include="MongoDbGenericRepository" Version="1.4.8" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="dotnet-reportgenerator-cli" Version="4.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="dotnet-reportgenerator-cli" Version="4.6.7" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <Content Include="appsettings*.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>  
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/IdentityResultAssert.cs
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/IdentityResultAssert.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -59,15 +61,20 @@ namespace Microsoft.AspNetCore.Identity.Test
         /// <param name="expectedLog">The expected log message.</param>
         public static void VerifyLogMessage(ILogger logger, string expectedLog)
         {
-            var testlogger = logger as ITestLogger;
-            if (testlogger != null)
+            var testLogger = logger as ITestLogger;
+            if (testLogger != null)
             {
-                Assert.Contains(expectedLog, testlogger.LogMessages);
+                Assert.True(testLogger.LogMessages.Any(x => x.Contains(expectedLog)), FormatErrorMessage(testLogger.LogMessages, expectedLog));
             }
             else
             {
                 Assert.False(true, "No logger registered");
             }
+        }
+
+        private static string FormatErrorMessage(IList<string> logMessages, string expectedLog)
+        {
+            return $"Failed to find in logs\n     Expected: '{expectedLog}'\n     Actual  : '{string.Join("\n     Actual  : '", logMessages)}'";
         }
     }
 }

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/IdentitySpecificationTestBase.cs
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/IdentitySpecificationTestBase.cs
@@ -581,7 +581,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
             var result = await userMgr.RemoveFromRoleAsync(user, roleName);
             IdentityResultAssert.IsFailure(result, _errorDescriber.UserNotInRole(roleName));
-            IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User {await userMgr.GetUserIdAsync(user)} is not in role {roleName}.");
+            IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User is not in role {roleName}.");
         }
 
         /// <summary>
@@ -606,7 +606,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
             Assert.True(await userMgr.IsInRoleAsync(user, roleName));
             IdentityResultAssert.IsFailure(await userMgr.AddToRoleAsync(user, roleName), _errorDescriber.UserAlreadyInRole(roleName));
-            IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User {await userMgr.GetUserIdAsync(user)} is already in role {roleName}.");
+            IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User is already in role {roleName}.");
         }
 
         /// <summary>

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/UserManagerSpecificationTests.cs
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/Specification/UserManagerSpecificationTests.cs
@@ -246,11 +246,11 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(newUser));
             var error = _errorDescriber.InvalidUserName("");
             IdentityResultAssert.IsFailure(await manager.SetUserNameAsync(newUser, ""), error);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(newUser)} validation failed: {error.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {error.Code}.");
 
             error = _errorDescriber.DuplicateUserName(newUsername);
             IdentityResultAssert.IsFailure(await manager.SetUserNameAsync(newUser, newUsername), error);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(newUser)} validation failed: {error.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {error.Code}.");
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             SetUserPasswordHash(user, manager.PasswordHasher.HashPassword(user, "New"));
             IdentityResultAssert.IsSuccess(await manager.UpdateAsync(user));
             Assert.False(await manager.CheckPasswordAsync(user, "password"));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Invalid password for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Invalid password for user");
             Assert.True(await manager.CheckPasswordAsync(user, "New"));
         }
 
@@ -378,7 +378,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.UserValidators.Clear();
             manager.UserValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.CreateAsync(user), AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user) ?? NullValue} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.UserValidators.Clear();
             manager.UserValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.UpdateAsync(user), AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user) ?? NullValue} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.UserValidators.Add(new AlwaysBadValidator());
             var result = await manager.CreateAsync(user);
             IdentityResultAssert.IsFailure(result, AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user) ?? NullValue} validation failed: {AlwaysBadValidator.ErrorMessage.Code};{AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {AlwaysBadValidator.ErrorMessage.Code};{AlwaysBadValidator.ErrorMessage.Code}.");
             Assert.Equal(2, result.Errors.Count());
         }
 
@@ -479,7 +479,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.AddPasswordAsync(user, "password"),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
         /// <summary>
@@ -522,7 +522,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.ChangePasswordAsync(user, "password", "new"),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user) ?? NullValue} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.PasswordValidators.Clear();
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.CreateAsync(user, "password"), AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user) ?? NullValue} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
         /// <summary>
@@ -637,7 +637,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(await manager.HasPasswordAsync(user));
             IdentityResultAssert.IsFailure(await manager.AddPasswordAsync(user, "password"),
                 "User already has a password set.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} already has a password.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User already has a password.");
         }
 
         /// <summary>
@@ -873,7 +873,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, "password"));
             var result = await manager.ChangePasswordAsync(user, "bogus", "newpassword");
             IdentityResultAssert.IsFailure(result, "Incorrect password.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Change password failed for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Change password failed for user");
         }
 
         /// <summary>
@@ -976,7 +976,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.AddLoginAsync(user, login));
             var result = await manager.AddLoginAsync(user, login);
             IdentityResultAssert.IsFailure(result, _errorDescriber.LoginAlreadyAssociated());
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"AddLogin for user {await manager.GetUserIdAsync(user)} failed because it was already associated with another user.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"AddLogin for user failed because it was already associated with another user.");
         }
 
         // Email tests
@@ -1119,7 +1119,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.ResetPasswordAsync(user, token, newPassword),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
             Assert.True(await manager.CheckPasswordAsync(user, password));
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
@@ -1145,7 +1145,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             IdentityResultAssert.IsFailure(await manager.ResetPasswordAsync(user, "bogus", newPassword), "Invalid token.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ResetPassword for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ResetPassword for user.");
             Assert.True(await manager.CheckPasswordAsync(user, password));
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
@@ -1173,13 +1173,13 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(await manager.VerifyUserTokenAsync(user, "Static", "test", token));
 
             Assert.False(await manager.VerifyUserTokenAsync(user, "Static", "test2", token));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test2 for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test2 for user.");
 
             Assert.False(await manager.VerifyUserTokenAsync(user, "Static", "test", token + "a"));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test for user.");
 
             Assert.False(await manager.VerifyUserTokenAsync(user2, "Static", "test", token));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test for user { await manager.GetUserIdAsync(user2)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test for user.");
         }
 
         /// <summary>
@@ -1227,7 +1227,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             IdentityResultAssert.IsFailure(await manager.ConfirmEmailAsync(user, "bogus"), "Invalid token.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: EmailConfirmation for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: EmailConfirmation for user.");
         }
 
         /// <summary>
@@ -1249,7 +1249,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.NotNull(token);
             IdentityResultAssert.IsSuccess(await manager.ChangePasswordAsync(user, "password", "newpassword"));
             IdentityResultAssert.IsFailure(await manager.ConfirmEmailAsync(user, token), "Invalid token.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: EmailConfirmation for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: EmailConfirmation for user.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
         }
 
@@ -1276,7 +1276,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.True(await mgr.IsLockedOutAsync(user));
             Assert.True(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
-            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User {await mgr.GetUserIdAsync(user)} is locked out.");
+            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User is locked out.");
 
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
@@ -1306,7 +1306,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.True(await mgr.IsLockedOutAsync(user));
             Assert.True(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
-            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User {await mgr.GetUserIdAsync(user)} is locked out.");
+            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User is locked out.");
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
 
@@ -1370,7 +1370,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.True(await mgr.IsLockedOutAsync(user));
             Assert.True(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
-            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User {await mgr.GetUserIdAsync(user)} is locked out.");
+            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User is locked out.");
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
 
@@ -1412,7 +1412,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.False(await mgr.GetLockoutEnabledAsync(user));
             IdentityResultAssert.IsFailure(await mgr.SetLockoutEndDateAsync(user, new DateTimeOffset()),
                 "Lockout is not enabled for this user.");
-            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"Lockout for user {await mgr.GetUserIdAsync(user)} failed because lockout is not enabled for this user.");
+            IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"Lockout for user failed because lockout is not enabled for this user.");
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
 
@@ -1556,7 +1556,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var stamp = await manager.GetSecurityStampAsync(user);
             IdentityResultAssert.IsFailure(await manager.ChangePhoneNumberAsync(user, "111-111-1111", "bogus"),
                 "Invalid token.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangePhoneNumber:111-111-1111 for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangePhoneNumber:111-111-1111 for user.");
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             Assert.Equal("123-456-7890", await manager.GetPhoneNumberAsync(user));
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
@@ -1611,7 +1611,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(await manager.VerifyChangePhoneNumberTokenAsync(user, token2, num2));
             Assert.False(await manager.VerifyChangePhoneNumberTokenAsync(user, token2, num1));
             Assert.False(await manager.VerifyChangePhoneNumberTokenAsync(user, token1, num2));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangePhoneNumber:111-123-4567 for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangePhoneNumber:111-123-4567 for user");
         }
 
         /// <summary>
@@ -1717,7 +1717,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var stamp = await manager.GetSecurityStampAsync(user);
             IdentityResultAssert.IsFailure(await manager.ChangeEmailAsync(user, "whatevah@foo.boop", "bogus"),
                 "Invalid token.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangeEmail:whatevah@foo.boop for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangeEmail:whatevah@foo.boop for user.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             Assert.Equal(await manager.GetEmailAsync(user), oldEmail);
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
@@ -1745,7 +1745,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var token1 = await manager.GenerateChangeEmailTokenAsync(user, "forgot@alrea.dy");
             IdentityResultAssert.IsFailure(await manager.ChangeEmailAsync(user, "oops@foo.boop", token1),
                 "Invalid token.");
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangeEmail:oops@foo.boop for user { await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: ChangeEmail:oops@foo.boop for user.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             Assert.Equal(await manager.GetEmailAsync(user), oldEmail);
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
@@ -1777,7 +1777,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.NotNull(token);
             IdentityResultAssert.IsSuccess(await manager.UpdateSecurityStampAsync(user));
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, factorId, token));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user");
         }
 
         /// <summary>
@@ -2002,7 +2002,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.NotNull(token);
             IdentityResultAssert.IsSuccess(await manager.UpdateSecurityStampAsync(user));
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, factorId, token));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user");
         }
 
         /// <summary>
@@ -2022,7 +2022,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var token = await manager.GenerateTwoFactorTokenAsync(user, "Phone");
             Assert.NotNull(token);
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, "Email", token));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user");
         }
 
         /// <summary>
@@ -2040,7 +2040,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var user = CreateTestUser(phoneNumber: "4251234567");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, "Phone", "bogus"));
-            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
+            IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user");
         }
 
         /// <summary>

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
@@ -1,8 +1,7 @@
 ﻿{
   "MongoDbSettings": {
-    "localConnectionString": "mongodb://localhost:27017",
-    "ConnectionString": "mongodb://rise-x-app-nda-cdb:YfhsMfTI4gYYzHWJE8On4q8TTf3uhcJFeVMM9gnu2VjNX4Yc5YigsbSkHHKU0y8GMrB0l1Vh8JxfBRBYXJKMjw%3D%3D@rise-x-app-nda-cdb.mongo.cosmos.azure.com:10255/?authSource=admin&replicaSet=globaldb&maxIdleTimeMS=120000&readPreference=primary&retryWrites=false&ssl=true",
-    "DatabaseName": "unit_tests"
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "MongoDbTests"
   },
   "Logging": {
     "IncludeScopes": {},

--- a/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
+++ b/test/AspNetCore.Identity.MongoDbCore.IntegrationTests/appsettings.json
@@ -1,7 +1,8 @@
 ﻿{
   "MongoDbSettings": {
-    "ConnectionString": "mongodb://localhost:27017",
-    "DatabaseName": "MongoDbTests"
+    "localConnectionString": "mongodb://localhost:27017",
+    "ConnectionString": "mongodb://rise-x-app-nda-cdb:YfhsMfTI4gYYzHWJE8On4q8TTf3uhcJFeVMM9gnu2VjNX4Yc5YigsbSkHHKU0y8GMrB0l1Vh8JxfBRBYXJKMjw%3D%3D@rise-x-app-nda-cdb.mongo.cosmos.azure.com:10255/?authSource=admin&replicaSet=globaldb&maxIdleTimeMS=120000&readPreference=primary&retryWrites=false&ssl=true",
+    "DatabaseName": "unit_tests"
   },
   "Logging": {
     "IncludeScopes": {},


### PR DESCRIPTION
Updated the project to dotnet 6.0:
1.  Removed support for netcoreapp3.1 instead going for net6.0 and netstandard2.1
2. I fixed the unit tests by removing references to the error checking with {user} embedded in the error, for some reason the user id is no longer sent in the error message. I also updated the error checking code for error messages to be a little more relaxed and do a contains rather than explicit equals.
3. There are two sign in tests that were failing, In order to fix, a claim was added to the user in both external and non external tests. Possibly something that used to add a default claim no longer adds this?
4. Updated the Yaml file to include dotnet 6 instead of 3.1, this has not been tested.