### PR TITLE
refactor: use IMongoRepository instead of IMongoDbContext in the MongoUserStore and MongoRoleStore classes to allow custom solutions for those using the library

### DIFF
--- a/src/Extensions/MongoDbIdentityBuilderExtensions.cs
+++ b/src/Extensions/MongoDbIdentityBuilderExtensions.cs
@@ -93,12 +93,12 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddSingleton<IMongoRepository>(new MongoRepository(mongoDbContext));
             builder.Services.TryAddScoped<IUserStore<TUser>>(provider =>
             {
-                return new MongoUserStore<TUser, TRole, IMongoDbContext, TKey>(provider.GetService<IMongoDbContext>());
+                return new MongoUserStore<TUser, TRole, IMongoDbContext, TKey>(provider.GetService<IMongoRepository>());
             });
 
             builder.Services.TryAddScoped<IRoleStore<TRole>>(provider =>
             {
-                return new MongoRoleStore<TRole, IMongoDbContext, TKey>(provider.GetService<IMongoDbContext>());
+                return new MongoRoleStore<TRole, IMongoDbContext, TKey>(provider.GetService<IMongoRepository>());
             });
             return builder;
         }

--- a/src/Infrastructure/MongoRepository.cs
+++ b/src/Infrastructure/MongoRepository.cs
@@ -1,4 +1,5 @@
-﻿using MongoDbGenericRepository;
+﻿using MongoDB.Driver;
+using MongoDbGenericRepository;
 
 namespace AspNetCore.Identity.MongoDbCore.Infrastructure
 {
@@ -7,6 +8,13 @@ namespace AspNetCore.Identity.MongoDbCore.Infrastructure
     /// </summary>
     public interface IMongoRepository : IBaseMongoRepository
     {
+        /// <summary>
+        /// Get a collection.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document used to define the collection name.</typeparam>
+        /// <returns>Mongo collection of <typeparamref name="TDocument"/>.</returns>
+        IMongoCollection<TDocument> GetCollection<TDocument>();
+
         /// <summary>
         /// Drops a collections.
         /// </summary>
@@ -47,6 +55,10 @@ namespace AspNetCore.Identity.MongoDbCore.Infrastructure
         public MongoRepository(IMongoDbContext mongoDbContext) : base(mongoDbContext)
         {
         }
+
+        /// <inheritdoc/>
+        public IMongoCollection<TDocument> GetCollection<TDocument>() =>
+            MongoDbContext.GetCollection<TDocument>();
 
         /// <summary>
         /// Drops a collections.

--- a/src/MongoRoleStore.cs
+++ b/src/MongoRoleStore.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -27,9 +26,9 @@ namespace AspNetCore.Identity.MongoDbCore
         /// <summary>
         /// Constructs a new instance of <see cref="MongoRoleStore{TRole}"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IMongoDbContext"/>.</param>
+        /// <param name="mongoRepository">The <see cref="IMongoRepository"/>.</param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public MongoRoleStore(IMongoDbContext context, IdentityErrorDescriber describer = null) : base(context, describer) { }
+        public MongoRoleStore(IMongoRepository mongoRepository, IdentityErrorDescriber describer = null) : base(mongoRepository, describer) { }
     }
 
     /// <summary>
@@ -44,9 +43,9 @@ namespace AspNetCore.Identity.MongoDbCore
         /// <summary>
         /// Constructs a new instance of <see cref="MongoRoleStore{TRole, TContext}"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IMongoDbContext"/>.</param>
+        /// <param name="mongoRepository">The <see cref="IMongoRepository"/>.</param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public MongoRoleStore(TContext context, IdentityErrorDescriber describer = null) : base(context, describer) { }
+        public MongoRoleStore(IMongoRepository mongoRepository, IdentityErrorDescriber describer = null) : base(mongoRepository, describer) { }
     }
 
     /// <summary>
@@ -65,9 +64,9 @@ namespace AspNetCore.Identity.MongoDbCore
         /// <summary>
         /// Constructs a new instance of <see cref="MongoRoleStore{TRole, TContext, TKey}"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IMongoDbContext"/>.</param>
+        /// <param name="mongoRepository">The <see cref="IMongoRepository"/>.</param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public MongoRoleStore(IMongoDbContext context, IdentityErrorDescriber describer = null) : base(context, describer) { }
+        public MongoRoleStore(IMongoRepository mongoRepository, IdentityErrorDescriber describer = null) : base(mongoRepository, describer) { }
     }
 
     /// <summary>
@@ -90,38 +89,23 @@ namespace AspNetCore.Identity.MongoDbCore
         /// <summary>
         /// Constructs a new instance of <see cref="MongoRoleStore{TRole, TContext, TKey, TUserRole, TRoleClaim}"/>.
         /// </summary>
-        /// <param name="context">The <see cref="IMongoDbContext"/>.</param>
+        /// <param name="mongoRepository">The <see cref="IMongoRepository"/>.</param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public MongoRoleStore(IMongoDbContext context, IdentityErrorDescriber describer = null)
+        public MongoRoleStore(IMongoRepository mongoRepository, IdentityErrorDescriber describer = null)
         {
-            if (context == null)
+            if (mongoRepository == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(mongoRepository));
             }
-            Context = context;
+
+            _mongoRepository = mongoRepository;
             ErrorDescriber = describer ?? new IdentityErrorDescriber();
         }
 
         private bool _disposed;
 
-
-        /// <summary>
-        /// Gets the database context for this store.
-        /// </summary>
-        private IMongoDbContext Context { get; }
-
-        private IMongoRepository _mongoRepository;
-        private IMongoRepository MongoRepository
-        {
-            get
-            {
-                if (_mongoRepository == null)
-                {
-                    _mongoRepository = new MongoRepository(Context);
-                }
-                return _mongoRepository;
-            }
-        }
+        private readonly IMongoRepository _mongoRepository;
+        private IMongoRepository MongoRepository => _mongoRepository;
 
         /// <summary>
         /// A navigation property for the roles the store contains.
@@ -131,7 +115,7 @@ namespace AspNetCore.Identity.MongoDbCore
         /// <summary>
         /// A navigation property for the roles the store contains.
         /// </summary>
-        public virtual IMongoCollection<TRole> RolesCollection => Context.GetCollection<TRole>();
+        public virtual IMongoCollection<TRole> RolesCollection => _mongoRepository.GetCollection<TRole>();
 
         /// <summary>
         /// Gets or sets the <see cref="IdentityErrorDescriber"/> for any error that occurred with the current operation.


### PR DESCRIPTION
In the project I'm working on, I needed to update the MongoDB.Driver package to version 3.3.0, and I was getting an error that the MongoDB.Driver.Core assembly version 2.28.0 could not be found when trying to call the ProjectManyAsync method.
I solved the problem by creating a new implementation based on MongoRepository, calling the same methods from MongoDB.Driver, but using version 3.3.0.

I found this workaround until I can update the MongoDB.Driver package to version 3.3.0 in the AspNetCore.Identity.MongoDbCore and mongodb-generic-repository projects.